### PR TITLE
fix: Use GitHub schema components by default

### DIFF
--- a/src/main/java/no/sikt/generator/ApiData.java
+++ b/src/main/java/no/sikt/generator/ApiData.java
@@ -113,7 +113,7 @@ public class ApiData {
                 && nonNull(openApiGithub.get().getComponents().getSchemas())
             ) {
                 openApiGithub.get().getComponents().getSchemas().forEach((key,value) -> {
-                    logger.info("Adding schema {} from github", key);
+                    logger.info("Setting schema {} from GitHub", key);
                     this.openapiApiGateway.getComponents().getSchemas().put(key, value);
                 });
             }

--- a/src/main/java/no/sikt/generator/ApiData.java
+++ b/src/main/java/no/sikt/generator/ApiData.java
@@ -113,10 +113,8 @@ public class ApiData {
                 && nonNull(openApiGithub.get().getComponents().getSchemas())
             ) {
                 openApiGithub.get().getComponents().getSchemas().forEach((key,value) -> {
-                    if (isNull(this.openapiApiGateway.getComponents().getSchemas().get(key))) {
-                        logger.info("Adding schema " + key + " from github");
-                        this.openapiApiGateway.getComponents().getSchemas().put(key, value);
-                    }
+                    logger.info("Adding schema {} from github", key);
+                    this.openapiApiGateway.getComponents().getSchemas().put(key, value);
                 });
             }
 

--- a/src/test/java/no/sikt/generator/handlers/GenerateExternalDocsHandlerTest.java
+++ b/src/test/java/no/sikt/generator/handlers/GenerateExternalDocsHandlerTest.java
@@ -171,6 +171,19 @@ class GenerateExternalDocsHandlerTest {
     }
 
     @Test
+    void shouldOverrideExistingSchemasFromGithub() {
+        setupTestCasesFromFilesWithGithubOpenapi("schema-override", List.of(Pair.of("api.yaml", Optional.of(
+            "github.yaml"))));
+
+        handler.handleRequest(null, null, null);
+        var openApi = readGeneratedOpenApi();
+
+        var resourceResponse = openApi.getComponents().getSchemas().get("ResourceResponse");
+        var idProperty = (io.swagger.v3.oas.models.media.Schema<?>) resourceResponse.getProperties().get("id");
+        assertThat(idProperty.getExample(), is(equalTo("12345")));
+    }
+
+    @Test
     void shouldIncludeExternalSchemaWhenItsDirectlyReferencedFromResponse() {
         var openapi = generateOpenApiFromExternalSpecs();
 

--- a/src/test/java/no/sikt/generator/handlers/GenerateInternalDocsHandlerTest.java
+++ b/src/test/java/no/sikt/generator/handlers/GenerateInternalDocsHandlerTest.java
@@ -312,6 +312,19 @@ class GenerateInternalDocsHandlerTest {
     }
 
     @Test
+    void shouldOverrideExistingSchemasFromGithub() {
+        setupTestCasesFromFilesWithGithubOpenapi("schema-override", List.of(Pair.of("api.yaml", Optional.of(
+            "github.yaml"))));
+
+        handler.handleRequest(null, null, null);
+        var openApi = readGeneratedOpenApi();
+
+        var resourceResponse = openApi.getComponents().getSchemas().get("ResourceResponse");
+        var idProperty = (io.swagger.v3.oas.models.media.Schema<?>) resourceResponse.getProperties().get("id");
+        assertThat(idProperty.getExample(), is(equalTo("12345")));
+    }
+
+    @Test
     void shouldSortSchemasAlphabetically() {
         setupNvaMocks();
 

--- a/src/test/resources/openapi_docs/schema-override/api.yaml
+++ b/src/test/resources/openapi_docs/schema-override/api.yaml
@@ -1,0 +1,38 @@
+openapi: "3.0.1"
+info:
+  title: "Schema Override API"
+  description: "API for testing schema override from GitHub"
+  version: "1.0.0"
+servers:
+  - url: "https://api.sandbox.nva.aws.unit.no/{basePath}"
+    variables:
+      basePath:
+        default: "schema-override"
+paths:
+  /resource:
+    get:
+      tags:
+        - "external"
+      summary: "Get resource"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceResponse"
+components:
+  schemas:
+    ResourceResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  securitySchemes:
+    CognitoUserPool:
+      type: "apiKey"
+      name: "Authorization"
+      in: "header"
+      x-amazon-apigateway-authtype: "cognito_user_pools"

--- a/src/test/resources/openapi_docs/schema-override/github.yaml
+++ b/src/test/resources/openapi_docs/schema-override/github.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: Schema Override API
+  description: API for testing schema override from GitHub
+  version: '1.0.0'
+paths:
+  /resource:
+    get:
+      tags:
+        - external
+      summary: Get resource
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceResponse"
+components:
+  schemas:
+    ResourceResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "12345"
+        name:
+          type: string
+          example: "Test Resource"
+  securitySchemes:
+    CognitoUserPool:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools


### PR DESCRIPTION
Removes the `isNull` guard so GitHub schemas always replace API Gateway schemas, instead of only filling in missing ones. This ensures richer schemas (with example values, x- extensions, etc.) from the GitHub/S3 source of truth are preserved in the generated Swagger UI.
