### PR TITLE
feat: Add handler serving individual OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,56 @@
 # nva-swagger-generator
 
-A service for fetching documentation (swagger) from multiple API Gateways and publishing a single swagger file
+Fetches the OpenAPI (Swagger) documentation for NVA's services and publishes it as Swagger UI sites on S3 + CloudFront.
+
+It produces two kinds of output:
+
+- **Combined docs**: all services merged into a single spec, in two variants.
+  - **external** (public): only operations tagged `external`.
+  - **internal** (HTTP basic auth): all operations.
+- **Per-service docs** (`/services/`): each service's source OpenAPI files rendered verbatim, so all examples and descriptions are preserved (no merging).
+  A landing page lists every service, and each links to a Swagger UI page with a spec picker.
+  Served on the internal site only, side by side with the combined docs.
+
+## Where to see the published docs
+
+`<env>` is one of `dev`, `test`, `sandbox`.
+
+| Site                   | Non-prod                                                      | Prod                                                |
+| ---------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
+| External (public)      | `https://swagger-ui.<env>.nva.aws.unit.no/`                   | `https://swagger-ui.nva.unit.no/`                   |
+| Internal (basic auth)  | `https://swagger-ui-internal.<env>.nva.aws.unit.no/`          | `https://swagger-ui-internal.nva.unit.no/`          |
+| Per-service (internal) | `https://swagger-ui-internal.<env>.nva.aws.unit.no/services/` | `https://swagger-ui-internal.nva.unit.no/services/` |
+
+## How it works
+
+Inputs:
+
+- Each service's source OpenAPI files are uploaded to the `OpenApiDocsBucket` S3 bucket by the infra master pipeline's `CopyDocs` Lambda, on every service deploy.
+- Swagger UI static assets are downloaded from GitHub by `InstallSwaggerUiHandler`.
+
+Lambda handlers (scheduled, no API Gateway trigger):
+
+- `GenerateExternalDocsHandler`: builds the combined external spec, writes it to the external bucket, invalidates CloudFront.
+- `GenerateInternalDocsHandler`: builds the combined internal spec (all operations) plus per-API YAML, writes to the internal bucket.
+- `GenerateServiceDocsHandler`: renders each source spec verbatim under `/services/` on the internal bucket (landing page, `api.html` spec picker, `apis.json`, and the specs).
+- `PublishDocumentationsHandler`: manages API Gateway documentation versions.
+- `InstallSwaggerUiHandler`: installs the Swagger UI assets into both buckets (no schedule; invoked manually or by the post-deploy script below).
+
+## Deploy
+
+This assumes you have configured AWS CLI with an SSO session named `sikt` and account profiles named `nva-<environment>`.
+
+Deployment is via AWS SAM (`template.yaml`), built and shipped by the service's CodePipeline (`buildspec.yaml`) as part of the NVA master pipeline.
+
+The doc-generating handlers are scheduled and do not run on deploy, so after the stack deploys to an environment, populate the per-service site once:
+
+```sh
+# Log in once per session (the SSO token is reused across profiles under the `sikt` session):
+aws sso login --sso-session sikt
+
+# Initialize the per service site in each environment:
+scripts/publish-services-docs.sh nva-sandbox   # repeat per env (nva-e2e, nva-dev, nva-test, nva-prod)
+
+# Optionally, pass the username/password to verify the landing page is live:
+DOCS_BASIC_AUTH=user:pass scripts/publish-services-docs.sh nva-sandbox
+```

--- a/scripts/publish-services-docs.sh
+++ b/scripts/publish-services-docs.sh
@@ -27,10 +27,15 @@ command -v aws >/dev/null 2>&1 || {
   exit 1
 }
 
+# Single scratch file for Lambda responses, reused across invocations and removed on
+# any exit (including a set -e abort mid-invoke), so error paths never leak it.
+payload_file="$(mktemp)"
+trap 'rm -f "$payload_file"' EXIT
+
 invoke_handler() {
   local label="$1"
   local name_filter="$2"
-  local function_name payload_file metadata payload
+  local function_name metadata payload
 
   function_name="$(aws lambda list-functions --profile "$profile" \
     --query "Functions[?contains(FunctionName, '$name_filter')].FunctionName" \
@@ -50,12 +55,10 @@ invoke_handler() {
 
   echo "==> Invoking $label"
   echo "    $function_name"
-  payload_file="$(mktemp)"
   # --cli-read-timeout 0: the handlers can run longer than the default 60s socket timeout.
   metadata="$(aws lambda invoke --profile "$profile" \
     --function-name "$function_name" --cli-read-timeout 0 "$payload_file")"
   payload="$(cat "$payload_file")"
-  rm -f "$payload_file"
 
   case "$metadata" in
     *FunctionError*)

--- a/scripts/publish-services-docs.sh
+++ b/scripts/publish-services-docs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Publish the per-service OpenAPI docs site (/services/) for ONE environment.
+#
+# InstallSwaggerUiHandler and GenerateServiceDocsHandler are scheduled (cron) and
+# do NOT run on stack deploy, so after the swagger-generator stack deploys to an
+# environment this script invokes them once to populate the site. Run it once per
+# environment; the cron keeps the site fresh afterward.
+#
+# Usage:
+#   scripts/publish-services-docs.sh <aws-profile>
+#     e.g. scripts/publish-services-docs.sh nva-sandbox
+#
+#   Set DOCS_BASIC_AUTH=user:pass (as an env var) to enable the landing-page liveness check:
+#     e.g. DOCS_BASIC_AUTH=username:password scripts/publish-services-docs.sh nva-prod
+
+set -euo pipefail
+
+profile="${1:-}"
+if [ -z "$profile" ]; then
+  echo "Usage: $0 <aws-profile>   (e.g. nva-sandbox)" >&2
+  exit 2
+fi
+
+command -v aws >/dev/null 2>&1 || {
+  echo "ERROR: aws CLI not found on PATH." >&2
+  exit 1
+}
+
+invoke_handler() {
+  local label="$1"
+  local name_filter="$2"
+  local function_name payload_file metadata payload
+
+  function_name="$(aws lambda list-functions --profile "$profile" \
+    --query "Functions[?contains(FunctionName, '$name_filter')].FunctionName" \
+    --output text)"
+
+  if [ -z "$function_name" ] || [ "$function_name" = "None" ]; then
+    echo "ERROR: no Lambda matching '$name_filter' found in profile '$profile'." >&2
+    exit 1
+  fi
+  case "$function_name" in
+    *[[:space:]]*)
+      echo "ERROR: '$name_filter' matched multiple functions:" >&2
+      echo "  $function_name" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "==> Invoking $label"
+  echo "    $function_name"
+  payload_file="$(mktemp)"
+  # --cli-read-timeout 0: the handlers can run longer than the default 60s socket timeout.
+  metadata="$(aws lambda invoke --profile "$profile" \
+    --function-name "$function_name" --cli-read-timeout 0 "$payload_file")"
+  payload="$(cat "$payload_file")"
+  rm -f "$payload_file"
+
+  case "$metadata" in
+    *FunctionError*)
+      echo "ERROR: $label reported a function error:" >&2
+      echo "  ${payload:-$metadata}" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ -n "$payload" ] && [ "$payload" != "null" ]; then
+    echo "    OK, response: $payload"
+  else
+    echo "    OK"
+  fi
+}
+
+# Resolve the internal docs host for an environment
+docs_host_for_profile() {
+  case "$1" in
+    *e2e*) echo "swagger-ui-internal.e2e.nva.aws.unit.no" ;;
+    *sandbox*) echo "swagger-ui-internal.sandbox.nva.aws.unit.no" ;;
+    *dev*) echo "swagger-ui-internal.dev.nva.aws.unit.no" ;;
+    *test*) echo "swagger-ui-internal.test.nva.aws.unit.no" ;;
+    *prod*) echo "swagger-ui-internal.nva.unit.no" ;;
+    *) echo "" ;;
+  esac
+}
+
+# 1. Install/refresh swagger-ui assets at the root of both buckets (api.html depends on these).
+invoke_handler "InstallSwaggerUiHandler" "InstallSwaggerUi"
+
+# 2. Generate the per-service docs site under /services/ (landing + api.html + apis.json + specs).
+invoke_handler "GenerateServiceDocsHandler" "GenerateService"
+
+echo
+host="$(docs_host_for_profile "$profile")"
+docs_url="https://${host:-<internal-docs-host>}/services/index.html"
+if [ -n "$host" ] && [ -n "${DOCS_BASIC_AUTH:-}" ]; then
+  echo "==> Verifying $docs_url"
+  status="$(curl -sS -u "$DOCS_BASIC_AUTH" \
+    -o /dev/null -w '%{http_code}' "$docs_url" || echo "request-failed")"
+  echo "    HTTP $status (expect 200; CloudFront may need a moment after invalidation)"
+else
+  echo "Done. Skipping liveness check (set DOCS_BASIC_AUTH=user:pass to enable it)."
+  echo "Verify manually at $docs_url (behind basic auth)."
+fi

--- a/swagger-generator/build.gradle
+++ b/swagger-generator/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation(nvaCatalog.log4j.core)
     implementation(nvaCatalog.slf4j.api)
     implementation(nvaLibs.s3)
+    testImplementation(nvaCatalog.assertj.core)
     testImplementation(nvaCatalog.hamcrest)
     testImplementation(nvaCatalog.junit.jupiter.api)
     testImplementation(nvaCatalog.mockito.core)

--- a/swagger-generator/src/main/java/no/sikt/generator/ApplicationConstants.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/ApplicationConstants.java
@@ -28,7 +28,7 @@ public final class ApplicationConstants {
     return ENVIRONMENT.readEnv("EXTERNAL_BUCKET_NAME");
   }
 
-  private static String readInternalBucketName() {
+  public static String readInternalBucketName() {
     return ENVIRONMENT.readEnv("INTERNAL_BUCKET_NAME");
   }
 

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -111,13 +111,12 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
     var entry = new LinkedHashMap<String, String>();
     entry.put(URL, SPECS_DIRECTORY + slug + YAML_EXTENSION);
     entry.put(NAME, extractTitle(content, slug));
-    entry.put(SOURCE, baseName(s3Object.key()));
+    entry.put(SOURCE, sourceLabel(s3Object.key()));
     return entry;
   }
 
-  private static String baseName(String key) {
-    var fileName = key.substring(key.lastIndexOf('/') + 1);
-    return Strings.CI.removeEnd(fileName, YAML_EXTENSION);
+  private static String sourceLabel(String key) {
+    return Strings.CI.removeEnd(key, YAML_EXTENSION);
   }
 
   private String readSourceDoc(String key) {

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -21,17 +21,14 @@ import java.util.stream.Collectors;
 import no.sikt.generator.CloudFrontClientSupplier;
 import no.sikt.generator.CloudFrontHighLevelClient;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.paths.UnixPath;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
 /**
  * Handler that serves each service's source OpenAPI doc verbatim under a {@code services/} prefix
@@ -51,18 +48,16 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
   public static final String API_PAGE_RESOURCE = "services-api.html";
   public static final String INITIALIZER_RESOURCE = "services-swagger-initializer.js";
   public static final String YAML_EXTENSION = ".yaml";
-  public static final int MAX_KEYS = 1000;
   private static final String URL = "url";
   private static final String NAME = "name";
   private static final String SOURCE = "source";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GenerateServiceDocsHandler.class);
-  private final S3Client inputS3Client;
+  private final S3Driver inputS3Driver;
   private final S3Client outputS3Client;
   private final CloudFrontHighLevelClient cloudFrontHighLevelClient;
   private final OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
   private final ObjectMapper objectMapper = new ObjectMapper();
-  private final String openApiBucketName = readOpenApiBucketName();
 
   public GenerateServiceDocsHandler() {
     this(
@@ -75,7 +70,7 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
       S3Client inputS3Client,
       S3Client outputS3Client,
       CloudFrontHighLevelClient cloudFrontHighLevelClient) {
-    this.inputS3Client = inputS3Client;
+    this.inputS3Driver = new S3Driver(inputS3Client, readOpenApiBucketName());
     this.outputS3Client = outputS3Client;
     this.cloudFrontHighLevelClient = cloudFrontHighLevelClient;
   }
@@ -94,16 +89,15 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
     cloudFrontHighLevelClient.invalidateAll(INTERNAL_CLOUD_FRONT_DISTRIBUTION);
   }
 
-  private List<S3Object> listSourceDocs() {
-    var request = ListObjectsRequest.builder().bucket(openApiBucketName).maxKeys(MAX_KEYS).build();
-    return inputS3Client.listObjects(request).contents().stream()
-        .filter(s3Object -> s3Object.key().endsWith(YAML_EXTENSION))
-        .sorted(Comparator.comparing(S3Object::key))
+  private List<String> listSourceDocs() {
+    return inputS3Driver.listAllFiles(UnixPath.EMPTY_PATH).stream()
+        .map(UnixPath::toString)
+        .filter(key -> key.endsWith(YAML_EXTENSION))
+        .sorted()
         .toList();
   }
 
-  private Map<String, String> publishSpec(S3Object s3Object) {
-    var key = s3Object.key();
+  private Map<String, String> publishSpec(String key) {
     var content = readSourceDoc(key);
     writeToOutput(SPECS_PREFIX + key, content, "application/yaml");
     LOGGER.info("Published service spec for {}", key);
@@ -121,8 +115,7 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
   }
 
   private String readSourceDoc(String key) {
-    var request = GetObjectRequest.builder().bucket(openApiBucketName).key(key).build();
-    return inputS3Client.getObject(request, ResponseTransformer.toBytes()).asUtf8String();
+    return inputS3Driver.getFile(UnixPath.of(key));
   }
 
   private String extractTitle(String content, String fallback) {

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -1,0 +1,174 @@
+package no.sikt.generator.handlers;
+
+import static no.sikt.generator.ApplicationConstants.INTERNAL_BUCKET_NAME;
+import static no.sikt.generator.ApplicationConstants.INTERNAL_CLOUD_FRONT_DISTRIBUTION;
+import static no.sikt.generator.ApplicationConstants.readOpenApiBucketName;
+import static no.sikt.generator.Utils.readResource;
+import static nva.commons.core.attempt.Try.attempt;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import no.sikt.generator.CloudFrontClientSupplier;
+import no.sikt.generator.CloudFrontHighLevelClient;
+import no.unit.nva.s3.S3Driver;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * Handler that serves each service's source OpenAPI doc verbatim under a {@code services/} prefix
+ * on the internal Swagger UI bucket. Unlike the combine pipeline, it does not touch API Gateway and
+ * does not merge specs, so all examples and descriptions are preserved.
+ */
+public class GenerateServiceDocsHandler implements RequestStreamHandler {
+
+  public static final String SERVICES_PREFIX = "services/";
+  public static final String SPECS_DIRECTORY = "specs/";
+  public static final String SPECS_PREFIX = SERVICES_PREFIX + SPECS_DIRECTORY;
+  public static final String MANIFEST_KEY = SERVICES_PREFIX + "apis.json";
+  public static final String INDEX_KEY = SERVICES_PREFIX + "index.html";
+  public static final String API_PAGE_KEY = SERVICES_PREFIX + "api.html";
+  public static final String INITIALIZER_KEY = SERVICES_PREFIX + "swagger-initializer.js";
+  public static final String INDEX_RESOURCE = "services-index.html";
+  public static final String API_PAGE_RESOURCE = "services-api.html";
+  public static final String INITIALIZER_RESOURCE = "services-swagger-initializer.js";
+  public static final String YAML_EXTENSION = ".yaml";
+  public static final int MAX_KEYS = 1000;
+  private static final String URL = "url";
+  private static final String NAME = "name";
+  private static final String SOURCE = "source";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GenerateServiceDocsHandler.class);
+  private final S3Client inputS3Client;
+  private final S3Client outputS3Client;
+  private final CloudFrontHighLevelClient cloudFrontHighLevelClient;
+  private final OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final String openApiBucketName = readOpenApiBucketName();
+
+  public GenerateServiceDocsHandler() {
+    this(
+        S3Driver.defaultS3Client().build(),
+        S3Driver.defaultS3Client().build(),
+        new CloudFrontHighLevelClient(CloudFrontClientSupplier.getSupplier()));
+  }
+
+  public GenerateServiceDocsHandler(
+      S3Client inputS3Client,
+      S3Client outputS3Client,
+      CloudFrontHighLevelClient cloudFrontHighLevelClient) {
+    this.inputS3Client = inputS3Client;
+    this.outputS3Client = outputS3Client;
+    this.cloudFrontHighLevelClient = cloudFrontHighLevelClient;
+  }
+
+  @Override
+  public void handleRequest(InputStream input, OutputStream output, Context context) {
+    var sourceDocs = listSourceDocs();
+    LOGGER.info("Found {} source OpenAPI files", sourceDocs.size());
+
+    var manifestEntries = sourceDocs.stream().map(this::publishSpec).toList();
+
+    writeManifest(manifestEntries);
+    writeStaticAsset(INDEX_KEY, INDEX_RESOURCE, "text/html");
+    writeStaticAsset(API_PAGE_KEY, API_PAGE_RESOURCE, "text/html");
+    writeStaticAsset(INITIALIZER_KEY, INITIALIZER_RESOURCE, "application/javascript");
+    cloudFrontHighLevelClient.invalidateAll(INTERNAL_CLOUD_FRONT_DISTRIBUTION);
+  }
+
+  private List<S3Object> listSourceDocs() {
+    var request = ListObjectsRequest.builder().bucket(openApiBucketName).maxKeys(MAX_KEYS).build();
+    return inputS3Client.listObjects(request).contents().stream()
+        .filter(s3Object -> s3Object.key().endsWith(YAML_EXTENSION))
+        .sorted(Comparator.comparing(S3Object::key))
+        .toList();
+  }
+
+  private Map<String, String> publishSpec(S3Object s3Object) {
+    var content = readSourceDoc(s3Object.key());
+    var slug = toSlug(s3Object.key());
+    writeToOutput(SPECS_PREFIX + slug + YAML_EXTENSION, content, "application/yaml");
+    LOGGER.info("Published service spec for {}", s3Object.key());
+
+    var entry = new LinkedHashMap<String, String>();
+    entry.put(URL, SPECS_DIRECTORY + slug + YAML_EXTENSION);
+    entry.put(NAME, extractTitle(content, slug));
+    entry.put(SOURCE, baseName(s3Object.key()));
+    return entry;
+  }
+
+  private static String baseName(String key) {
+    var fileName = key.substring(key.lastIndexOf('/') + 1);
+    return Strings.CI.removeEnd(fileName, YAML_EXTENSION);
+  }
+
+  private String readSourceDoc(String key) {
+    var request = GetObjectRequest.builder().bucket(openApiBucketName).key(key).build();
+    return inputS3Client.getObject(request, ResponseTransformer.toBytes()).asUtf8String();
+  }
+
+  private String extractTitle(String content, String fallback) {
+    return attempt(() -> openApiParser.readContents(content).getOpenAPI().getInfo().getTitle())
+        .toOptional()
+        .filter(StringUtils::isNotBlank)
+        .orElse(fallback);
+  }
+
+  private static String toSlug(String key) {
+    var withoutExtension = Strings.CI.removeEnd(key, YAML_EXTENSION);
+    return withoutExtension.replaceAll("[^a-zA-Z0-9]+", "-");
+  }
+
+  private void writeManifest(List<Map<String, String>> entries) {
+    disambiguateDuplicateNames(entries);
+    var sorted =
+        entries.stream()
+            .map(entry -> Map.of(URL, entry.get(URL), NAME, entry.get(NAME)))
+            .sorted(Comparator.comparing(entry -> entry.get(NAME)))
+            .toList();
+    var json = attempt(() -> objectMapper.writeValueAsString(sorted)).orElseThrow();
+    writeToOutput(MANIFEST_KEY, json, "application/json");
+  }
+
+  private void disambiguateDuplicateNames(List<Map<String, String>> entries) {
+    var nameCounts =
+        entries.stream()
+            .collect(Collectors.groupingBy(entry -> entry.get(NAME), Collectors.counting()));
+    entries.stream()
+        .filter(entry -> nameCounts.get(entry.get(NAME)) > 1)
+        .forEach(entry -> entry.put(NAME, entry.get(NAME) + " (" + entry.get(SOURCE) + ")"));
+  }
+
+  private void writeStaticAsset(String key, String resource, String contentType) {
+    writeToOutput(key, readResource(resource), contentType);
+  }
+
+  private void writeToOutput(String key, String content, String contentType) {
+    var request =
+        PutObjectRequest.builder()
+            .bucket(INTERNAL_BUCKET_NAME)
+            .key(key)
+            .contentType(contentType)
+            .build();
+    var body = RequestBody.fromString(content, StandardCharsets.UTF_8);
+    attempt(() -> outputS3Client.putObject(request, body)).orElseThrow();
+  }
+}

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -103,19 +103,20 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
   }
 
   private Map<String, String> publishSpec(S3Object s3Object) {
-    var content = readSourceDoc(s3Object.key());
-    var slug = toSlug(s3Object.key());
-    writeToOutput(SPECS_PREFIX + slug + YAML_EXTENSION, content, "application/yaml");
-    LOGGER.info("Published service spec for {}", s3Object.key());
+    var key = s3Object.key();
+    var content = readSourceDoc(key);
+    writeToOutput(SPECS_PREFIX + key, content, "application/yaml");
+    LOGGER.info("Published service spec for {}", key);
 
+    var label = stripExtension(key);
     var entry = new LinkedHashMap<String, String>();
-    entry.put(URL, SPECS_DIRECTORY + slug + YAML_EXTENSION);
-    entry.put(NAME, extractTitle(content, slug));
-    entry.put(SOURCE, sourceLabel(s3Object.key()));
+    entry.put(URL, SPECS_DIRECTORY + key);
+    entry.put(NAME, extractTitle(content, label));
+    entry.put(SOURCE, label);
     return entry;
   }
 
-  private static String sourceLabel(String key) {
+  private static String stripExtension(String key) {
     return Strings.CI.removeEnd(key, YAML_EXTENSION);
   }
 
@@ -129,11 +130,6 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
         .toOptional()
         .filter(StringUtils::isNotBlank)
         .orElse(fallback);
-  }
-
-  private static String toSlug(String key) {
-    var withoutExtension = Strings.CI.removeEnd(key, YAML_EXTENSION);
-    return withoutExtension.replaceAll("[^a-zA-Z0-9]+", "-");
   }
 
   private void writeManifest(List<Map<String, String>> entries) {

--- a/swagger-generator/src/main/resources/services-api.html
+++ b/swagger-generator/src/main/resources/services-api.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>NVA API documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Swagger UI assets are served from the bucket root, installed by InstallSwaggerUiHandler. -->
+    <link rel="stylesheet" type="text/css" href="/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="/swagger-ui-bundle.js" charset="UTF-8"></script>
+    <script src="/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+    <script src="./swagger-initializer.js" charset="UTF-8"></script>
+  </body>
+</html>

--- a/swagger-generator/src/main/resources/services-index.html
+++ b/swagger-generator/src/main/resources/services-index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>NVA API documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        color: #3b4151;
+        line-height: 1.5;
+        background: #f4f6f8;
+      }
+      h1 {
+        font-size: 1.8rem;
+        margin-bottom: 0.25rem;
+      }
+      p {
+        color: #4a5568;
+        margin-top: 0;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin-top: 1.5rem;
+      }
+      li {
+        margin: 0.6rem 0;
+      }
+      a {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.85rem 1.1rem;
+        background: #ffffff;
+        border: 1px solid #d8dde6;
+        border-radius: 8px;
+        text-decoration: none;
+        color: #1f6feb;
+        font-weight: 600;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+        transition:
+          border-color 0.15s ease,
+          box-shadow 0.15s ease,
+          transform 0.05s ease;
+      }
+      a::after {
+        content: "›";
+        color: #9aa4b2;
+        font-size: 1.4rem;
+        line-height: 1;
+      }
+      a:hover {
+        border-color: #1f6feb;
+        box-shadow: 0 2px 10px rgba(31, 111, 235, 0.18);
+      }
+      a:hover::after {
+        color: #1f6feb;
+      }
+      a:active {
+        transform: translateY(1px);
+      }
+      .status {
+        color: #9aa4b2;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>NVA API documentation</h1>
+      <p>
+        OpenAPI documentation for NVA's services, one specification per service.
+        Select a service to view its API. You can also switch between services
+        from the dropdown at the top of each documentation page.
+      </p>
+      <ul id="api-list">
+        <li class="status">Loading available services...</li>
+      </ul>
+    </main>
+    <script>
+      fetch("./apis.json")
+        .then(function (response) {
+          return response.json();
+        })
+        .then(function (apis) {
+          var list = document.getElementById("api-list");
+          list.innerHTML = "";
+          if (!apis.length) {
+            var empty = document.createElement("li");
+            empty.className = "status";
+            empty.textContent = "No services available.";
+            list.appendChild(empty);
+            return;
+          }
+          apis.forEach(function (api) {
+            var item = document.createElement("li");
+            var link = document.createElement("a");
+            link.href = "api.html?api=" + encodeURIComponent(api.name);
+            link.textContent = api.name;
+            item.appendChild(link);
+            list.appendChild(item);
+          });
+        });
+    </script>
+  </body>
+</html>

--- a/swagger-generator/src/main/resources/services-index.html
+++ b/swagger-generator/src/main/resources/services-index.html
@@ -87,6 +87,9 @@
     <script>
       fetch("./apis.json")
         .then(function (response) {
+          if (!response.ok) {
+            throw new Error("Failed to fetch apis.json: HTTP " + response.status);
+          }
           return response.json();
         })
         .then(function (apis) {
@@ -107,6 +110,16 @@
             item.appendChild(link);
             list.appendChild(item);
           });
+        })
+        .catch(function (error) {
+          console.error(error);
+          var list = document.getElementById("api-list");
+          list.innerHTML = "";
+          var failed = document.createElement("li");
+          failed.className = "status";
+          failed.textContent =
+            "Could not load the list of services. Please try again later.";
+          list.appendChild(failed);
         });
     </script>
   </body>

--- a/swagger-generator/src/main/resources/services-swagger-initializer.js
+++ b/swagger-generator/src/main/resources/services-swagger-initializer.js
@@ -1,3 +1,4 @@
+/* global SwaggerUIBundle, SwaggerUIStandalonePreset */
 window.onload = function () {
   // Each entry in apis.json is one service's source OpenAPI doc, served verbatim.
   // Swagger UI renders the selected spec with all its examples and descriptions intact.

--- a/swagger-generator/src/main/resources/services-swagger-initializer.js
+++ b/swagger-generator/src/main/resources/services-swagger-initializer.js
@@ -1,0 +1,30 @@
+window.onload = function () {
+  // Each entry in apis.json is one service's source OpenAPI doc, served verbatim.
+  // Swagger UI renders the selected spec with all its examples and descriptions intact.
+  // The landing page (index.html) links here with ?api=<name> to preselect a spec;
+  // the dropdown still lets the user switch between all services.
+  fetch('./apis.json')
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (urls) {
+      var requestedName = new URLSearchParams(window.location.search).get('api');
+      var requestedMatch = urls.filter(function (entry) {
+        return entry.name === requestedName;
+      });
+      var primaryName = requestedMatch.length
+        ? requestedMatch[0].name
+        : urls.length
+          ? urls[0].name
+          : undefined;
+      window.ui = SwaggerUIBundle({
+        urls: urls,
+        'urls.primaryName': primaryName,
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+        layout: 'StandaloneLayout',
+      });
+    });
+};

--- a/swagger-generator/src/main/resources/services-swagger-initializer.js
+++ b/swagger-generator/src/main/resources/services-swagger-initializer.js
@@ -5,6 +5,9 @@ window.onload = function () {
   // the dropdown still lets the user switch between all services.
   fetch('./apis.json')
     .then(function (response) {
+      if (!response.ok) {
+        throw new Error('Failed to fetch apis.json: HTTP ' + response.status);
+      }
       return response.json();
     })
     .then(function (urls) {
@@ -26,5 +29,10 @@ window.onload = function () {
         plugins: [SwaggerUIBundle.plugins.DownloadUrl],
         layout: 'StandaloneLayout',
       });
+    })
+    .catch(function (error) {
+      console.error(error);
+      document.getElementById('swagger-ui').textContent =
+        'Could not load the API documentation. Please try again later.';
     });
 };

--- a/swagger-generator/src/main/resources/services-swagger-initializer.js
+++ b/swagger-generator/src/main/resources/services-swagger-initializer.js
@@ -16,6 +16,9 @@ window.onload = function () {
       var requestedMatch = urls.filter(function (entry) {
         return entry.name === requestedName;
       });
+      if (requestedName && !requestedMatch.length) {
+        showNotice('The requested API "' + requestedName + '" is not available.');
+      }
       var primaryName = requestedMatch.length
         ? requestedMatch[0].name
         : urls.length
@@ -37,3 +40,13 @@ window.onload = function () {
         'Could not load the API documentation. Please try again later.';
     });
 };
+
+function showNotice(message) {
+  var container = document.getElementById('swagger-ui');
+  var notice = document.createElement('div');
+  notice.textContent = message;
+  notice.style.cssText =
+    'max-width: 1460px; margin: 1rem auto; padding: 0.75rem 1rem;' +
+    'background: #fff3cd; border: 1px solid #ffe69c; border-radius: 6px; color: #664d03;';
+  container.parentNode.insertBefore(notice, container);
+}

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -177,8 +177,10 @@ class GenerateServiceDocsHandlerTest {
     assertSoftly(
         softly -> {
           softly.assertThat(landingPage).contains("api.html?api=");
+          softly.assertThat(landingPage).contains("Could not load the list of services");
           softly.assertThat(apiPage).contains("swagger-ui");
           softly.assertThat(initializer).contains("apis.json");
+          softly.assertThat(initializer).contains("Could not load the API documentation");
         });
   }
 

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -31,6 +31,7 @@ class GenerateServiceDocsHandlerTest {
 
   private static final String SERVICE_A_KEY = "service-a/openapi.yaml";
   private static final String API_A_RESOURCE = "openapi_docs/api-a.yaml";
+  private static final String API_B_RESOURCE = "openapi_docs/api-b.yaml";
 
   private GenerateServiceDocsHandler handler;
   private S3Driver inputS3Driver;
@@ -81,20 +82,20 @@ class GenerateServiceDocsHandlerTest {
   @Test
   void shouldWriteEachSourceSpecVerbatim() {
     uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
-    uploadResourceToS3("service-b/openapi.yaml", "openapi_docs/api-b.yaml");
+    uploadResourceToS3("service-b/openapi.yaml", API_B_RESOURCE);
 
     invokeHandler();
 
-    var specA = outputS3Driver.getFile(UnixPath.of("services/specs/service-a-openapi.yaml"));
-    var specB = outputS3Driver.getFile(UnixPath.of("services/specs/service-b-openapi.yaml"));
+    var specA = outputS3Driver.getFile(UnixPath.of("services/specs/service-a/openapi.yaml"));
+    var specB = outputS3Driver.getFile(UnixPath.of("services/specs/service-b/openapi.yaml"));
     assertThat(specA).isEqualTo(readResource(API_A_RESOURCE));
-    assertThat(specB).isEqualTo(readResource("openapi_docs/api-b.yaml"));
+    assertThat(specB).isEqualTo(readResource(API_B_RESOURCE));
   }
 
   @Test
   void shouldWriteManifestListingApiTitlesAndUrls() {
     uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
-    uploadResourceToS3("service-b/openapi.yaml", "openapi_docs/api-b.yaml");
+    uploadResourceToS3("service-b/openapi.yaml", API_B_RESOURCE);
 
     invokeHandler();
 
@@ -103,8 +104,8 @@ class GenerateServiceDocsHandlerTest {
         softly -> {
           softly.assertThat(manifest).contains("Api A");
           softly.assertThat(manifest).contains("Api B");
-          softly.assertThat(manifest).contains("specs/service-a-openapi.yaml");
-          softly.assertThat(manifest).contains("specs/service-b-openapi.yaml");
+          softly.assertThat(manifest).contains("specs/service-a/openapi.yaml");
+          softly.assertThat(manifest).contains("specs/service-b/openapi.yaml");
         });
   }
 
@@ -139,13 +140,29 @@ class GenerateServiceDocsHandlerTest {
   }
 
   @Test
-  void shouldFallBackToSlugAsNameWhenTitleIsMissing() {
+  void shouldPreserveSourceKeyPathSoSpecsNeverCollide() {
+    uploadResourceToS3("a-b/openapi.yaml", API_A_RESOURCE);
+    uploadResourceToS3("a/b/openapi.yaml", API_B_RESOURCE);
+
+    invokeHandler();
+
+    var firstSpec = outputS3Driver.getFile(UnixPath.of("services/specs/a-b/openapi.yaml"));
+    var secondSpec = outputS3Driver.getFile(UnixPath.of("services/specs/a/b/openapi.yaml"));
+    assertSoftly(
+        softly -> {
+          softly.assertThat(firstSpec).isEqualTo(readResource(API_A_RESOURCE));
+          softly.assertThat(secondSpec).isEqualTo(readResource(API_B_RESOURCE));
+        });
+  }
+
+  @Test
+  void shouldFallBackToKeyPathAsNameWhenTitleIsMissing() {
     uploadResourceToS3("misc/not-openapi.yaml", "openapi_docs/not-openapi.yaml");
 
     invokeHandler();
 
     var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
-    assertThat(manifest).contains("misc-not-openapi");
+    assertThat(manifest).contains("misc/not-openapi");
   }
 
   @Test
@@ -177,7 +194,7 @@ class GenerateServiceDocsHandlerTest {
             .map(UnixPath::toString)
             .toList();
     assertThat(publishedSpecs)
-        .anyMatch(path -> path.contains("service-a-openapi.yaml"))
+        .anyMatch(path -> path.contains("service-a/openapi.yaml"))
         .noneMatch(path -> path.contains("readme"));
   }
 

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -109,17 +109,32 @@ class GenerateServiceDocsHandlerTest {
   }
 
   @Test
-  void shouldDisambiguateApisThatShareATitle() {
-    uploadResourceToS3("handle-service/handle-openapi.yaml", API_A_RESOURCE);
-    uploadResourceToS3("handle-service/openapi.yaml", API_A_RESOURCE);
+  void shouldDisambiguateDuplicateTitlesAndFilenames() {
+    uploadResourceToS3("a-service/openapi.yaml", API_A_RESOURCE);
+    uploadResourceToS3("b-service/openapi.yaml", API_A_RESOURCE);
 
     invokeHandler();
 
     var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
     assertSoftly(
         softly -> {
-          softly.assertThat(manifest).contains("Api A (handle-openapi)");
-          softly.assertThat(manifest).contains("Api A (openapi)");
+          softly.assertThat(manifest).contains("Api A (a-service/openapi)");
+          softly.assertThat(manifest).contains("Api A (b-service/openapi)");
+        });
+  }
+
+  @Test
+  void shouldDisambiguateDuplicateTitlesFromSameService() {
+    uploadResourceToS3("a-service/foo-openapi.yaml", API_A_RESOURCE);
+    uploadResourceToS3("a-service/bar-openapi.yaml", API_A_RESOURCE);
+
+    invokeHandler();
+
+    var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
+    assertSoftly(
+        softly -> {
+          softly.assertThat(manifest).contains("Api A (a-service/foo-openapi)");
+          softly.assertThat(manifest).contains("Api A (a-service/bar-openapi)");
         });
   }
 

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -1,0 +1,177 @@
+package no.sikt.generator.handlers;
+
+import static no.sikt.generator.ApplicationConstants.readInternalBucketName;
+import static no.sikt.generator.ApplicationConstants.readOpenApiBucketName;
+import static no.sikt.generator.Utils.readResource;
+import static no.sikt.generator.handlers.GenerateServiceDocsHandler.API_PAGE_KEY;
+import static no.sikt.generator.handlers.GenerateServiceDocsHandler.INDEX_KEY;
+import static no.sikt.generator.handlers.GenerateServiceDocsHandler.INITIALIZER_KEY;
+import static no.sikt.generator.handlers.GenerateServiceDocsHandler.MANIFEST_KEY;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+import no.sikt.generator.CloudFrontHighLevelClient;
+import no.unit.nva.s3.S3Driver;
+import no.unit.nva.stubs.FakeS3Client;
+import nva.commons.core.paths.UnixPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationRequest;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationResponse;
+
+class GenerateServiceDocsHandlerTest {
+
+  private static final String SERVICE_A_KEY = "service-a/openapi.yaml";
+  private static final String API_A_RESOURCE = "openapi_docs/api-a.yaml";
+
+  private GenerateServiceDocsHandler handler;
+  private S3Driver inputS3Driver;
+  private S3Driver outputS3Driver;
+  private CloudFrontClient cloudFrontClient;
+
+  @SuppressWarnings({"PMD.CloseResource"})
+  @BeforeEach
+  void setup() {
+    var inputS3Client = new FakeS3Client();
+    var outputS3Client = new FakeS3Client();
+    inputS3Driver = new S3Driver(inputS3Client, readOpenApiBucketName());
+    outputS3Driver = new S3Driver(outputS3Client, readInternalBucketName());
+
+    var cloudFrontHighLevelClient = setupMockedCloudFrontClient();
+
+    handler =
+        new GenerateServiceDocsHandler(inputS3Client, outputS3Client, cloudFrontHighLevelClient);
+  }
+
+  @SuppressWarnings({"unchecked"})
+  private CloudFrontHighLevelClient setupMockedCloudFrontClient() {
+    var mockCloudFrontSupplier = mock(Supplier.class);
+    cloudFrontClient = mock(CloudFrontClient.class);
+    when(mockCloudFrontSupplier.get()).thenReturn(cloudFrontClient);
+    when(cloudFrontClient.createInvalidation(any(CreateInvalidationRequest.class)))
+        .thenReturn(CreateInvalidationResponse.builder().build());
+    return new CloudFrontHighLevelClient(mockCloudFrontSupplier);
+  }
+
+  private void uploadContentToS3(String key, String content) {
+    attempt(() -> inputS3Driver.insertFile(UnixPath.of(key), content)).orElseThrow();
+  }
+
+  private void uploadResourceToS3(String key, String resource) {
+    uploadContentToS3(key, readResource(resource));
+  }
+
+  private void invokeHandler() {
+    handler.handleRequest(null, null, null);
+  }
+
+  @Test
+  void shouldHaveConstructorWithNoArguments() {
+    assertThatNoException().isThrownBy(GenerateServiceDocsHandler::new);
+  }
+
+  @Test
+  void shouldWriteEachSourceSpecVerbatim() {
+    uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
+    uploadResourceToS3("service-b/openapi.yaml", "openapi_docs/api-b.yaml");
+
+    invokeHandler();
+
+    var specA = outputS3Driver.getFile(UnixPath.of("services/specs/service-a-openapi.yaml"));
+    var specB = outputS3Driver.getFile(UnixPath.of("services/specs/service-b-openapi.yaml"));
+    assertThat(specA).isEqualTo(readResource(API_A_RESOURCE));
+    assertThat(specB).isEqualTo(readResource("openapi_docs/api-b.yaml"));
+  }
+
+  @Test
+  void shouldWriteManifestListingApiTitlesAndUrls() {
+    uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
+    uploadResourceToS3("service-b/openapi.yaml", "openapi_docs/api-b.yaml");
+
+    invokeHandler();
+
+    var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
+    assertSoftly(
+        softly -> {
+          softly.assertThat(manifest).contains("Api A");
+          softly.assertThat(manifest).contains("Api B");
+          softly.assertThat(manifest).contains("specs/service-a-openapi.yaml");
+          softly.assertThat(manifest).contains("specs/service-b-openapi.yaml");
+        });
+  }
+
+  @Test
+  void shouldDisambiguateApisThatShareATitle() {
+    uploadResourceToS3("handle-service/handle-openapi.yaml", API_A_RESOURCE);
+    uploadResourceToS3("handle-service/openapi.yaml", API_A_RESOURCE);
+
+    invokeHandler();
+
+    var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
+    assertSoftly(
+        softly -> {
+          softly.assertThat(manifest).contains("Api A (handle-openapi)");
+          softly.assertThat(manifest).contains("Api A (openapi)");
+        });
+  }
+
+  @Test
+  void shouldFallBackToSlugAsNameWhenTitleIsMissing() {
+    uploadResourceToS3("misc/not-openapi.yaml", "openapi_docs/not-openapi.yaml");
+
+    invokeHandler();
+
+    var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
+    assertThat(manifest).contains("misc-not-openapi");
+  }
+
+  @Test
+  void shouldWriteLandingPageApiPageAndInitializer() {
+    uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
+
+    invokeHandler();
+
+    var landingPage = outputS3Driver.getFile(UnixPath.of(INDEX_KEY));
+    var apiPage = outputS3Driver.getFile(UnixPath.of(API_PAGE_KEY));
+    var initializer = outputS3Driver.getFile(UnixPath.of(INITIALIZER_KEY));
+    assertSoftly(
+        softly -> {
+          softly.assertThat(landingPage).contains("api.html?api=");
+          softly.assertThat(apiPage).contains("swagger-ui");
+          softly.assertThat(initializer).contains("apis.json");
+        });
+  }
+
+  @Test
+  void shouldNotWriteSpecForNonYamlFiles() {
+    uploadContentToS3("service-a/readme.txt", "not a spec");
+    uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
+
+    invokeHandler();
+
+    var publishedSpecs =
+        outputS3Driver.listAllFiles(UnixPath.of("services/specs")).stream()
+            .map(UnixPath::toString)
+            .toList();
+    assertThat(publishedSpecs)
+        .anyMatch(path -> path.contains("service-a-openapi.yaml"))
+        .noneMatch(path -> path.contains("readme"));
+  }
+
+  @Test
+  void shouldInvalidateCloudFront() {
+    uploadResourceToS3(SERVICE_A_KEY, API_A_RESOURCE);
+
+    invokeHandler();
+
+    verify(cloudFrontClient).createInvalidation(any(CreateInvalidationRequest.class));
+  }
+}

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -181,6 +181,7 @@ class GenerateServiceDocsHandlerTest {
           softly.assertThat(apiPage).contains("swagger-ui");
           softly.assertThat(initializer).contains("apis.json");
           softly.assertThat(initializer).contains("Could not load the API documentation");
+          softly.assertThat(initializer).contains("is not available");
         });
   }
 

--- a/swagger-generator/src/test/resources/openapi_docs/not-openapi.yaml
+++ b/swagger-generator/src/test/resources/openapi_docs/not-openapi.yaml
@@ -1,0 +1,2 @@
+some: value
+without: a title

--- a/template.yaml
+++ b/template.yaml
@@ -320,6 +320,24 @@ Resources:
           Properties:
             Schedule: cron(10 */4 ? * * *)
 
+  GenerateServiceDocsHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: swagger-generator
+      Description: Serves each service's source OpenAPI docs verbatim under /services/index.html
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambda_ReadOnlyAccess
+      Handler: no.sikt.generator.handlers.GenerateServiceDocsHandler::handleRequest
+      Runtime: java21
+      Role: !GetAtt SwaggerGeneratorRole.Arn
+      Timeout: 600
+      Events:
+        GenerateDocsScheduleEvent:
+          Type: Schedule
+          Properties:
+            Schedule: cron(20 */4 ? * * *)
+
   InstallSwaggerUiHandler:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Adds a new lambda that serves OpenAPI docs from individual services without modifying them. See example deployed in sandbox environment: https://swagger-ui-internal.sandbox.nva.aws.unit.no/services/index.html

Other changes:

- Adds relevant documentation to the README
- Adds a deployment script to simplify deployment