### PR TITLE
fix: Clean-up and refactoring for new doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It produces two kinds of output:
 
 ## Where to see the published docs
 
-`<env>` is one of `dev`, `test`, `sandbox`.
+`<env>` is one of `dev`, `test`, `sandbox`, `e2e`.
 
 | Site                   | Non-prod                                                      | Prod                                                |
 | ---------------------- | ------------------------------------------------------------- | --------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ It produces two kinds of output:
 
 `<env>` is one of `dev`, `test`, `sandbox`, `e2e`.
 
-| Site                   | Non-prod                                                      | Prod                                                |
-| ---------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
-| External (public)      | `https://swagger-ui.<env>.nva.aws.unit.no/`                   | `https://swagger-ui.nva.unit.no/`                   |
-| Internal (basic auth)  | `https://swagger-ui-internal.<env>.nva.aws.unit.no/`          | `https://swagger-ui-internal.nva.unit.no/`          |
-| Per-service (internal) | `https://swagger-ui-internal.<env>.nva.aws.unit.no/services/` | `https://swagger-ui-internal.nva.unit.no/services/` |
+| Site                   | Non-prod                                                                | Prod                                                          |
+| ---------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| External (public)      | `https://swagger-ui.<env>.nva.aws.unit.no/`                             | `https://swagger-ui.nva.unit.no/`                             |
+| Internal (basic auth)  | `https://swagger-ui-internal.<env>.nva.aws.unit.no/`                    | `https://swagger-ui-internal.nva.unit.no/`                    |
+| Per-service (internal) | `https://swagger-ui-internal.<env>.nva.aws.unit.no/services/index.html` | `https://swagger-ui-internal.nva.unit.no/services/index.html` |
 
 ## How it works
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.warning.mode=all
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 # Version of `nva-commons` used for version catalog and dependencies
-nvaCommonsVersion=2.8.2
+nvaCommonsVersion=2.9.0
 
 # Plugin versions
 foojayResolverVersion=1.0.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 commons-text = { strictly = '1.15.0' }
-swagger-v3 = { strictly = '2.2.51' }
-swagger-parser-v3 = { strictly = '2.1.44' }
+swagger-v3 = { strictly = '2.2.52' }
+swagger-parser-v3 = { strictly = '2.1.45' }
 
 [libraries]
 aws-sdk2-apigateway = { group = 'software.amazon.awssdk', name = 'apigateway' }

--- a/scripts/publish-services-docs.sh
+++ b/scripts/publish-services-docs.sh
@@ -2,10 +2,11 @@
 #
 # Publish the per-service OpenAPI docs site (/services/) for ONE environment.
 #
-# InstallSwaggerUiHandler and GenerateServiceDocsHandler are scheduled (cron) and
-# do NOT run on stack deploy, so after the swagger-generator stack deploys to an
-# environment this script invokes them once to populate the site. Run it once per
-# environment; the cron keeps the site fresh afterward.
+# Neither handler runs on stack deploy: GenerateServiceDocsHandler is on a cron
+# schedule and InstallSwaggerUiHandler has no trigger at all, so after the
+# swagger-generator stack deploys to an environment this script invokes them once
+# to populate the site. Run it once per environment; the cron keeps the generated
+# docs fresh afterward.
 #
 # Usage:
 #   scripts/publish-services-docs.sh <aws-profile>

--- a/swagger-generator/src/main/java/no/sikt/generator/ApplicationConstants.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/ApplicationConstants.java
@@ -28,7 +28,7 @@ public final class ApplicationConstants {
     return ENVIRONMENT.readEnv("EXTERNAL_BUCKET_NAME");
   }
 
-  public static String readInternalBucketName() {
+  private static String readInternalBucketName() {
     return ENVIRONMENT.readEnv("INTERNAL_BUCKET_NAME");
   }
 

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import no.sikt.generator.CloudFrontClientSupplier;
 import no.sikt.generator.CloudFrontHighLevelClient;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UnixPath;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -59,6 +60,7 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
   private final OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
   private final ObjectMapper objectMapper = new ObjectMapper();
 
+  @JacocoGenerated
   public GenerateServiceDocsHandler() {
     this(
         S3Driver.defaultS3Client().build(),

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -132,7 +132,7 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
     var sorted =
         entries.stream()
             .map(entry -> Map.of(URL, entry.get(URL), NAME, entry.get(NAME)))
-            .sorted(Comparator.comparing(entry -> entry.get(NAME)))
+            .sorted(Comparator.comparing(entry -> entry.get(NAME), String.CASE_INSENSITIVE_ORDER))
             .toList();
     var json = attempt(() -> objectMapper.writeValueAsString(sorted)).orElseThrow();
     writeToOutput(MANIFEST_KEY, json, "application/json");

--- a/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
+++ b/swagger-generator/src/main/java/no/sikt/generator/handlers/GenerateServiceDocsHandler.java
@@ -121,10 +121,14 @@ public class GenerateServiceDocsHandler implements RequestStreamHandler {
   }
 
   private String extractTitle(String content, String fallback) {
-    return attempt(() -> openApiParser.readContents(content).getOpenAPI().getInfo().getTitle())
-        .toOptional()
-        .filter(StringUtils::isNotBlank)
-        .orElse(fallback);
+    var title =
+        attempt(() -> openApiParser.readContents(content).getOpenAPI().getInfo().getTitle())
+            .toOptional()
+            .filter(StringUtils::isNotBlank);
+    if (title.isEmpty()) {
+      LOGGER.warn("No OpenAPI title found in {}, using the key path as name", fallback);
+    }
+    return title.orElse(fallback);
   }
 
   private void writeManifest(List<Map<String, String>> entries) {

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -1,6 +1,6 @@
 package no.sikt.generator.handlers;
 
-import static no.sikt.generator.ApplicationConstants.readInternalBucketName;
+import static no.sikt.generator.ApplicationConstants.INTERNAL_BUCKET_NAME;
 import static no.sikt.generator.ApplicationConstants.readOpenApiBucketName;
 import static no.sikt.generator.Utils.readResource;
 import static no.sikt.generator.handlers.GenerateServiceDocsHandler.API_PAGE_KEY;
@@ -9,7 +9,6 @@ import static no.sikt.generator.handlers.GenerateServiceDocsHandler.INITIALIZER_
 import static no.sikt.generator.handlers.GenerateServiceDocsHandler.MANIFEST_KEY;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -44,7 +43,7 @@ class GenerateServiceDocsHandlerTest {
     var inputS3Client = new FakeS3Client();
     var outputS3Client = new FakeS3Client();
     inputS3Driver = new S3Driver(inputS3Client, readOpenApiBucketName());
-    outputS3Driver = new S3Driver(outputS3Client, readInternalBucketName());
+    outputS3Driver = new S3Driver(outputS3Client, INTERNAL_BUCKET_NAME);
 
     var cloudFrontHighLevelClient = setupMockedCloudFrontClient();
 
@@ -72,11 +71,6 @@ class GenerateServiceDocsHandlerTest {
 
   private void invokeHandler() {
     handler.handleRequest(null, null, null);
-  }
-
-  @Test
-  void shouldHaveConstructorWithNoArguments() {
-    assertThatNoException().isThrownBy(GenerateServiceDocsHandler::new);
   }
 
   @Test

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -20,6 +20,7 @@ import no.sikt.generator.CloudFrontHighLevelClient;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.core.paths.UnixPath;
+import nva.commons.logutils.LogRecorder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
@@ -179,6 +180,16 @@ class GenerateServiceDocsHandlerTest {
 
     var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
     assertThat(manifest).contains("misc/not-openapi");
+  }
+
+  @Test
+  void shouldWarnWhenSpecHasNoTitle() {
+    uploadResourceToS3("misc/not-openapi.yaml", "openapi_docs/not-openapi.yaml");
+    var logRecorder = LogRecorder.forRoot(GenerateServiceDocsHandlerTest.class);
+
+    invokeHandler();
+
+    assertThat(logRecorder.messages()).anyMatch(message -> message.contains("No OpenAPI title"));
   }
 
   @Test

--- a/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
+++ b/swagger-generator/src/test/java/no/sikt/generator/handlers/GenerateServiceDocsHandlerTest.java
@@ -65,6 +65,15 @@ class GenerateServiceDocsHandlerTest {
     attempt(() -> inputS3Driver.insertFile(UnixPath.of(key), content)).orElseThrow();
   }
 
+  private static String minimalSpecWithTitle(String title) {
+    return """
+    openapi: 3.0.1
+    info:
+      title: %s
+    """
+        .formatted(title);
+  }
+
   private void uploadResourceToS3(String key, String resource) {
     uploadContentToS3(key, readResource(resource));
   }
@@ -101,6 +110,19 @@ class GenerateServiceDocsHandlerTest {
           softly.assertThat(manifest).contains("specs/service-a/openapi.yaml");
           softly.assertThat(manifest).contains("specs/service-b/openapi.yaml");
         });
+  }
+
+  @Test
+  void shouldSortManifestNamesCaseInsensitively() {
+    uploadContentToS3("a-service/openapi.yaml", minimalSpecWithTitle("apple API"));
+    uploadContentToS3("b-service/openapi.yaml", minimalSpecWithTitle("Banana API"));
+
+    invokeHandler();
+
+    var manifest = outputS3Driver.getFile(UnixPath.of(MANIFEST_KEY));
+    assertThat(manifest.indexOf("apple API"))
+        .isNotNegative()
+        .isLessThan(manifest.indexOf("Banana API"));
   }
 
   @Test


### PR DESCRIPTION
Changes:

- [fix: Correct handler scheduling comment in publish script](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/04763b4f451273acffe983ea4cb22dcfac01d82f)
- [refactor: Use JacocoGenerated convention for no-arg constructor](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/3b9c61918825e621f07ce95451fb5cd8d4ac008e)
- [fix: Sort service manifest names case-insensitively](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/92edb2a107d6cdf72e551adebcb625c12cf00ba6)
- [fix: Warn when a spec has no OpenAPI title](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/e20b81cd84e933ada0a9066d6bdcccd44664da5c)
- [docs: Include e2e in the environment list](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/7c3c1b547d35c96572edda3507511dfd626fadab)
- [build: Upgrade dependencies](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/eb9f87305abd97b2b0c09e57423bb08816bb397e)
- [docs: Fix link in README](https://github.com/BIBSYSDEV/nva-swagger-generator/pull/40/commits/34bd2b667cd542ac6cca30119bba08f1e5b1d0e0)

